### PR TITLE
POST Auth Parameter with HTTP Body

### DIFF
--- a/Source/PusherSwift.swift
+++ b/Source/PusherSwift.swift
@@ -433,8 +433,9 @@ public class PusherConnection: WebSocketDelegate {
     }
 
     private func sendAuthorisationRequest(endpoint: String, socket: String, channel: PusherChannel, callback: ((Dictionary<String, String>?) -> Void)? = nil) {
-        var request = NSMutableURLRequest(URL: NSURL(string: "\(endpoint)?socket_id=\(socket)&channel_name=\(channel.name)")!)
+        var request = NSMutableURLRequest(URL: NSURL(string: endpoint)!)
         request.HTTPMethod = "POST"
+        request.HTTPBody = "socket_id=\(socket)&channel_name=\(channel.name)".dataUsingEncoding(NSUTF8StringEncoding)
 
         if let handler = self.options.authRequestCustomizer {
             request = handler(request)


### PR DESCRIPTION
We have to send post auth data in HTTP Body

## :no_good:

```sh
# Current implementation
curl -XPOST 'https://circleci.com/auth/pusher?circle-token=foobar?socket_id=123456.87654321&channel_name=private-test'

# This also fails
curl -XPOST 'https://circleci.com/auth/pusher?circle-token=foobar&socket_id=123456.87654321&channel_name=private-test'
```

## :ok_woman:

```sh
curl 'https://circleci.com/auth/pusher?circle-token=foobar' \
  --data 'socket_id=123456.87654321&channel_name=private-test'
```

Replaces https://github.com/pusher-community/pusher-websocket-swift/pull/20